### PR TITLE
Changed -nostart to -shared

### DIFF
--- a/PalEdit/build/MainBuildRules
+++ b/PalEdit/build/MainBuildRules
@@ -64,7 +64,7 @@ rule SharedLibrary
 	MakeLocate $(lib) : $(LOCATE_MAIN_TARGET) ;
 	local linkFlags ;
 	if $(OSPLAT) = X86 {
-		linkFlags = -nostart -Xlinker -soname=\"$(lib)\" ;
+		linkFlags = -shared -Xlinker -soname=\"$(lib)\" ;
 	} else {
 		linkFlags = -xms ;
 	}

--- a/Paladin/Project.cpp
+++ b/Paladin/Project.cpp
@@ -805,7 +805,7 @@ Project::Link(void)
 			}
 			case TARGET_SHARED_LIB:
 			{
-				linkString << "-shared-Xlinker -soname=" << GetTargetName() << " ";
+				linkString << "-shared -Xlinker -soname=" << GetTargetName() << " ";
 				break;
 			}
 			default:

--- a/Paladin/Project.cpp
+++ b/Paladin/Project.cpp
@@ -805,7 +805,7 @@ Project::Link(void)
 			}
 			case TARGET_SHARED_LIB:
 			{
-				linkString << "-nostart -Xlinker -soname=" << GetTargetName() << " ";
+				linkString << "-shared-Xlinker -soname=" << GetTargetName() << " ";
 				break;
 			}
 			default:


### PR DESCRIPTION
Actual compilers on Haiku doesn't support the -nostart option. It's better to use -shared. With this change PalEdit can be compiled on x86_gcc4.
