### PR TITLE
Fixes #8. Adds Header file dependencies to project window

### DIFF
--- a/Paladin/ProjectList.cpp
+++ b/Paladin/ProjectList.cpp
@@ -20,7 +20,6 @@
 #include <TranslatorFormats.h>
 #include <TranslationUtils.h>
 #include <Window.h>
-#include <StringList.h>
 
 #include "DebugTools.h"
 #include "MsgDefs.h"
@@ -264,8 +263,6 @@ ProjectList::RefreshList(void)
 			SourceFileItem* fileItem = new SourceFileItem(file,1);
 
 			AddItem(fileItem);
-
-			// Also add dependencies
 			
 			BString abspath = file->GetPath().GetFullPath();
 			if (abspath[0] != '/') {
@@ -285,7 +282,6 @@ ProjectList::RefreshList(void)
 				InvalidateItem(IndexOf(fileItem));
 			}
 		}
-
 	}
 
 	if (Window() != NULL)

--- a/Paladin/ProjectList.cpp
+++ b/Paladin/ProjectList.cpp
@@ -286,31 +286,6 @@ ProjectList::RefreshList(void)
 			}
 		}
 
-		//WARNING: This function doesn't seem to ever get called
-		//WARNING: Final implementation of the below code is in ProjectWindow.cpp
-
-		STRACE(2,("Adding header files to UI\n"));
-
-		// Also add dependencies (header files)
-		SourceGroupItem* headergroupitem = new SourceGroupItem(group);
-		AddItem(headergroupitem);
-		headergroupitem->SetExpanded(group->expanded);
-
-		for (int32 j = 0; j < group->filelist.CountItems(); j++) {
-			SourceFile* file = group->filelist.ItemAt(j);
-			SourceFileItem* fileItem = new SourceFileItem(file,1);
-			BString dependencies = file->GetDependencies();
-			// Split string on comma to get individual files
-			BStringList deplist = BStringList();// = new BStringList();
-			dependencies.Split(",",true,deplist);
-			// Add item for each
-			for (int32 d = 0;d < deplist.CountStrings(); d++) {
-				BString dep = deplist.StringAt(d);
-				BStringItem* depitem = new BStringItem(dep);
-				AddItem(depitem,d+1);
-			}
-			// TODO ensure unique
-		}
 	}
 
 	if (Window() != NULL)

--- a/Paladin/ProjectWindow.cpp
+++ b/Paladin/ProjectWindow.cpp
@@ -203,13 +203,15 @@ ProjectWindow::ProjectWindow(BRect frame, Project* project)
 
 		// Also add dependencies (header files)
 		SourceGroupItem* headergroupitem = new SourceGroupItem(group);
-		headergroupitem->SetText("Header files");
+		BString headergroupname(group->name);
+		headergroupname += " dependencies";
+		headergroupitem->SetText(headergroupname);
 		fProjectList->AddItem(headergroupitem);
 		headergroupitem->SetExpanded(group->expanded);
 
 		for (int32 j = 0; j < group->filelist.CountItems(); j++) {
 			SourceFile* file = group->filelist.ItemAt(j);
-			SourceFileItem* fileItem = new SourceFileItem(file,1);
+			//SourceFileItem* fileItem = new SourceFileItem(file,1);
 			BString dependencies = file->GetDependencies();
 			// Split string on comma to get individual files
 			BStringList deplist = BStringList();// = new BStringList();
@@ -226,7 +228,11 @@ ProjectWindow::ProjectWindow(BRect frame, Project* project)
 					}
 				}
 				if (!found) {
-					fProjectList->AddUnder(depitem,headergroupitem);
+					// create source file item instead of string
+					//fProjectList->AddUnder(depitem,headergroupitem);
+					SourceFile* depfile = new SourceFile(dep);
+					SourceFileItem* depfileitem = new SourceFileItem(depfile,1);
+					fProjectList->AddUnder(depfileitem,headergroupitem);
 				}
 			}
 		}

--- a/Paladin/ProjectWindow.cpp
+++ b/Paladin/ProjectWindow.cpp
@@ -215,23 +215,28 @@ ProjectWindow::ProjectWindow(BRect frame, Project* project)
 			BString dependencies = file->GetDependencies();
 			// Split string on comma to get individual files
 			BStringList deplist = BStringList();// = new BStringList();
-			dependencies.Split(",",true,deplist);
+			dependencies.Split("|",true,deplist);
 			// Add item for each
 			for (int32 d = 0;d < deplist.CountStrings(); d++) {
 				BString dep = deplist.StringAt(d);
 				BStringItem* depitem = new BStringItem(dep);
 				//fProjectList->AddItem(depitem);
 				bool found = false;
-				for (int32 ed = 0;!found && ed < fProjectList->CountItemsUnder(headergroupitem,true);ed++) {
-					if (((BStringItem*)fProjectList->ItemUnderAt(headergroupitem,true,ed))->Text() == dep) {
+				STRACE(2,("Does dep exist?: %s\n",depitem->Text()));
+				int32 ed;
+				SourceFile* depfile = new SourceFile(dep);
+				SourceFileItem* depfileitem = new SourceFileItem(depfile,1);
+				for (ed = 0;!found && ed < fProjectList->CountItemsUnder(headergroupitem,true);ed++) {
+					STRACE(2,(" - Curitem text: %s\n",((SourceFileItem*)fProjectList->ItemUnderAt(headergroupitem,true,ed))->GetData()->GetPath().GetFullPath() ));
+					if (0 == strcmp( 
+							((SourceFileItem*)fProjectList->ItemUnderAt(headergroupitem,true,ed))->GetData()->GetPath().GetFullPath(), depitem->Text() )) {
+						STRACE(2,(" - Found!!!\n"));
 						found = true;
 					}
 				}
 				if (!found) {
 					// create source file item instead of string
 					//fProjectList->AddUnder(depitem,headergroupitem);
-					SourceFile* depfile = new SourceFile(dep);
-					SourceFileItem* depfileitem = new SourceFileItem(depfile,1);
 					fProjectList->AddUnder(depfileitem,headergroupitem);
 				}
 			}

--- a/Paladin/ProjectWindow.cpp
+++ b/Paladin/ProjectWindow.cpp
@@ -1,11 +1,13 @@
 /*
  * Copyright 2001-2010 DarkWyrm <bpmagic@columbus.rr.com>
  * Copyright 2014 John Scipione <jscipione@gmail.com>
+ * Copyright 2018 Adam Fowler <adamfowleruk@gmail.com>
  * Distributed under the terms of the MIT License.
  *
  * Authors:
  *		DarkWyrm, bpmagic@columbus.rr.com
  *		John Scipione, jscipione@gmail.com
+ *		Adam Fowler, adamfowleruk@gmail.com
  */
 
 
@@ -32,6 +34,7 @@
 #include <ScrollView.h>
 #include <String.h>
 #include <StringView.h>
+#include <StringList.h>
 #include <TypeConstants.h>
 #include <View.h>
 
@@ -194,6 +197,43 @@ ProjectWindow::ProjectWindow(BRect frame, Project* project)
 					fProjectList->InvalidateItem(fProjectList->IndexOf(fileitem));
 				}
 			}
+
+			// Now add header files
+		STRACE(2,("Adding header files to UI\n"));
+
+		// Also add dependencies (header files)
+		SourceGroupItem* headergroupitem = new SourceGroupItem(group);
+		headergroupitem->SetText("Header files");
+		fProjectList->AddItem(headergroupitem);
+		headergroupitem->SetExpanded(group->expanded);
+
+		for (int32 j = 0; j < group->filelist.CountItems(); j++) {
+			SourceFile* file = group->filelist.ItemAt(j);
+			SourceFileItem* fileItem = new SourceFileItem(file,1);
+			BString dependencies = file->GetDependencies();
+			// Split string on comma to get individual files
+			BStringList deplist = BStringList();// = new BStringList();
+			dependencies.Split(",",true,deplist);
+			// Add item for each
+			for (int32 d = 0;d < deplist.CountStrings(); d++) {
+				BString dep = deplist.StringAt(d);
+				BStringItem* depitem = new BStringItem(dep);
+				//fProjectList->AddItem(depitem);
+				bool found = false;
+				for (int32 ed = 0;!found && ed < fProjectList->CountItemsUnder(headergroupitem,true);ed++) {
+					if (((BStringItem*)fProjectList->ItemUnderAt(headergroupitem,true,ed))->Text() == dep) {
+						found = true;
+					}
+				}
+				if (!found) {
+					fProjectList->AddUnder(depitem,headergroupitem);
+				}
+			}
+		}
+
+
+
+
 		}
 	}
 


### PR DESCRIPTION
This patch provides the following features for Header Files in Projects:-
- Reads the DEPENDENCY lines within each group
- Creates a 'GROUP NAME dependencies' visual group for header files
- Lists each member of the dependencies within the group once only
- Double clicking a header file will allow it to be edited

Drawbacks: Assumes the Paladin Project File has been created with the DEPENDENCY= lines set correctly. This isn't always the case. See #31 

Known issues:-

1. UI allows drag/drop of source files in to new dependencies group. Just a UI glitch - doesn't affect the saved project files.
1. Group name set in English, not using L10N yet (I note the existing issue for that topic, so haven't fixed here)
1. It is possible to 'add source files' which adds h files in as SOURCE= items. Think this is more a bug with the add source files feature than this PR though.