### PR TITLE
Fixes #27. Restricts project open dialog boxes to pld files only

### DIFF
--- a/Paladin/Makefile
+++ b/Paladin/Makefile
@@ -48,6 +48,7 @@ SRCS = AboutWindow.cpp \
 	LibWindow.cpp \
 	Makemake.cpp \
 	Paladin.cpp \
+	PaladinFileFilter.cpp \
 	PrefsWindow.cpp \
 	Project.cpp \
 	ProjectList.cpp \

--- a/Paladin/Paladin.cpp
+++ b/Paladin/Paladin.cpp
@@ -32,7 +32,7 @@
 #include "SourceFile.h"
 #include "StartWindow.h"
 #include "TemplateWindow.h"
-
+#include "PaladinFileFilter.h"
 
 BPoint gProjectWindowPoint;
 static int sReturnCode = 0;
@@ -121,8 +121,8 @@ App::App(void)
 	BEntry entry(gLastProjectPath.GetFullPath());
 	entry_ref ref;
 	entry.GetRef(&ref);
-	fOpenPanel = new BFilePanel(B_OPEN_PANEL, &msgr, &ref, B_FILE_NODE, true,
-		new BMessage(B_REFS_RECEIVED));
+	fOpenPanel = new BFilePanel(B_OPEN_PANEL, &msgr, &ref, B_FILE_NODE, false,
+		new BMessage(B_REFS_RECEIVED), new PaladinFileFilter() );
 	fOpenPanel->Window()->SetTitle("Paladin: Open project");
 }
 

--- a/Paladin/PaladinFileFilter.cpp
+++ b/Paladin/PaladinFileFilter.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 Adam Fowler <adamfowleruk@gmail.com>
+ * Distributed under the terms of the MIT License.
+ *
+ * Authors:
+ * 		Adam Fowler, adamfowleruk@gmail.com
+ */
+#include "PaladinFileFilter.h"
+
+#include "Project.h"
+
+const char * PaladinFileFilter::valid_filetypes[] = {
+	"application/x-vnd.Be-directory",
+	PROJECT_MIME_TYPE
+};
+
+PaladinFileFilter::PaladinFileFilter() 
+{
+}
+
+PaladinFileFilter::~PaladinFileFilter()
+{
+}
+
+bool
+PaladinFileFilter::Filter(const entry_ref *ref, BNode *node, struct stat_beos *stat, const char *mimeType)
+{
+	for (int i = 0; valid_filetypes[i]; i++) {
+		if (0 == strcmp(valid_filetypes[i],mimeType)) {
+			return true;
+		}
+		BString name(ref->name);
+		name.ToUpper();
+		int32 l = name.FindLast('.');
+		if (l != B_ERROR) {
+			if (name.FindFirst(".PLD", l) != B_ERROR) return true;
+		}
+	}
+	return false;
+}
+

--- a/Paladin/PaladinFileFilter.h
+++ b/Paladin/PaladinFileFilter.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018 Adam Fowler <adamfowleruk@gmail.com>
+ * Distributed under the terms of the MIT License.
+ *
+ * Authors:
+ * 		Adam Fowler, adamfowleruk@gmail.com
+ */
+#ifndef PALADINFILEFILTER_H
+#define PALADINFILEFILTER_H
+
+#include <FilePanel.h>
+#include <Entry.h>
+
+class PaladinFileFilter : public BRefFilter
+{
+public:
+		PaladinFileFilter(void);
+		~PaladinFileFilter(void);
+	bool	Filter(const entry_ref *ref, BNode *node, 
+			struct stat_beos *stat, const char *mimeType);
+private:
+	static const char *	valid_filetypes[3];
+};
+
+#endif

--- a/Paladin/StartWindow.cpp
+++ b/Paladin/StartWindow.cpp
@@ -1,11 +1,13 @@
 /*
  * Copyright 2001-2010 DarkWyrm <bpmagic@columbus.rr.com>
  * Copyright 2014 John Scipione <jscipione@gmail.com>
+ * Copyright 2018 Adam Fowler <adamfowleruk@gmail.com>
  * Distributed under the terms of the MIT License.
  *
  * Authors:
  *		DarkWyrm, bpmagic@columbus.rr.com
  *		John Scipione, jscipione@gmail.com
+ *		Adam Fowler, adamfowleruk@gmail.com
  */
 
 

--- a/Paladin/StartWindow.cpp
+++ b/Paladin/StartWindow.cpp
@@ -36,6 +36,7 @@
 #include "Settings.h"
 #include "TemplateWindow.h"
 #include "TypedRefFilter.h"
+#include "PaladinFileFilter.h"
 
 
 enum
@@ -264,8 +265,8 @@ StartWindow::StartWindow(void)
 	BEntry entry(gProjectPath.GetFullPath());
 	entry_ref ref;
 	entry.GetRef(&ref);
-	fOpenPanel = new BFilePanel(B_OPEN_PANEL, &messager, &ref, B_FILE_NODE, true,
-		new BMessage(M_OPEN_PROJECT));
+	fOpenPanel = new BFilePanel(B_OPEN_PANEL, &messager, &ref, B_FILE_NODE, false,
+		new BMessage(M_OPEN_PROJECT),new PaladinFileFilter());
 	BString titleString(TR("Open project"));
 	titleString.Prepend("Paladin: ");
 	fOpenPanel->Window()->SetTitle(titleString.String());


### PR DESCRIPTION
Stops unexpected behaviour by only allowing a single PLD file to be opened by the Project Open button on the Start Window, or the File -> Open Project menu item.