### PR TITLE
Find now works with grep. Matches open at correct lines

### DIFF
--- a/Paladin/CodeLibWindow.cpp
+++ b/Paladin/CodeLibWindow.cpp
@@ -12,6 +12,7 @@
 #include <stdio.h>
 #include <TextView.h>
 
+#include "DebugTools.h"
 #include "DListView.h"
 #include "DPath.h"
 #include "Globals.h"
@@ -367,6 +368,7 @@ CodeLibWindow::MessageReceived(BMessage *msg)
 			{
 				RefListItem *refitem = (RefListItem*)fFileList->ItemAt(sel);
 				entry_ref ref = refitem->GetRef();
+				STRACE(2,("CodeLibWindow Launch"));
 				be_roster->Launch(&ref);
 				sel = fFileList->CurrentSelection(index++);
 			}

--- a/Paladin/FileActions.cpp
+++ b/Paladin/FileActions.cpp
@@ -9,6 +9,7 @@
 #include "DPath.h"
 #include "Globals.h"
 #include "Project.h"
+#include "DebugTools.h"
 
 void
 SpawnFileTypes(DPath path)
@@ -32,6 +33,7 @@ SpawnFileTypes(DPath path)
 	BMessage msg(B_REFS_RECEIVED);
 	msg.AddRef("refs",&ref);
 	
+	STRACE(2,("FileActions Launch"));
 	if (gPlatform == PLATFORM_R5 || gPlatform == PLATFORM_ZETA)
 		be_roster->Launch("application/x-vnd.Be-MIMA",&msg);
 	else

--- a/Paladin/FileUtils.cpp
+++ b/Paladin/FileUtils.cpp
@@ -12,6 +12,7 @@
 #include "Icons.h"
 #include "Paladin.h"
 #include "Project.h"
+#include "DebugTools.h"
 
 
 #undef B_TRANSLATION_CONTEXT
@@ -71,6 +72,7 @@ FindAndOpenFile(BMessage *msg)
 				entry_ref fileref = FindFile(folderref,filename.String());
 				if (fileref.name)
 				{
+					STRACE(2,("FileUtils open file message"));
 					BMessage refMessage(B_REFS_RECEIVED);
 					refMessage.AddRef("refs",&fileref);
 					be_app->PostMessage(&refMessage);

--- a/Paladin/Paladin.cpp
+++ b/Paladin/Paladin.cpp
@@ -532,13 +532,12 @@ App::OpenFile(entry_ref ref, int32 line)
 		}
 	}
 	
-//	BMessage msg(B_REFS_RECEIVED);
-	BMessage msg(EDIT_OPEN_FILE);
-	msg.AddRef("refs",&ref);
+	BMessage* msg = new BMessage(B_REFS_RECEIVED);
+	msg->AddRef("refs",&ref);
 	if (line >= 0)
-		msg.AddInt32("line",line);
-	
-	be_roster->Launch(&ref);
+		msg->AddInt32("be:line",line);
+	STRACE(2,("Paladin Launching File Ref: $s:%i",ref.name,line));
+	be_roster->Launch(&ref,msg);
 }
 
 


### PR DESCRIPTION
Not closing #157 yet as replace/replaceall not yet complete. This commit fixes Find and double clicking a result opens the correct line number (passes be:line and &fileref correctly). Before you couldn't double click to open a file at all. Hence wanting to merge multiple times from this branch.