### PR TITLE
Get it to compile on R1 beta4

### DIFF
--- a/Paladin/AsciiWindow.cpp
+++ b/Paladin/AsciiWindow.cpp
@@ -8,6 +8,7 @@
  *		John Scipione, jscipione@gmail.com
  */
 
+#define _GNU_SOURCE
 
 #include "AsciiWindow.h"
 

--- a/Paladin/DebugTools.cpp
+++ b/Paladin/DebugTools.cpp
@@ -129,9 +129,6 @@ void PrintStatus(status_t value)
 		case B_FILE_ERROR:
 			outstr="B_FILE_ERROR";
 			break;
-		case B_FILE_NOT_FOUND:
-			outstr="B_FILE_NOT_FOUND ";
-			break;
 		case B_ENTRY_NOT_FOUND:
 			outstr="B_ENTRY_NOT_FOUND ";
 			break;

--- a/Paladin/Paladin.cpp
+++ b/Paladin/Paladin.cpp
@@ -654,7 +654,7 @@ App::CreateNewProject(const BMessage &settings)
 		
 		BString wildcard("'");
 		wildcard << sourcePath.GetFullPath() << "'/*";
-		ShellHelper shell("cp -a ");
+		ShellHelper shell("cp --no-preserve=mode,ownership ");
 		shell << wildcard;
 		shell.AddQuotedArg(destPath.GetFullPath());
 		shell.Run();

--- a/Paladin/ProjectWindow.cpp
+++ b/Paladin/ProjectWindow.cpp
@@ -1685,6 +1685,10 @@ ProjectWindow::CreateMenuBar()
 	BString aboutStr(B_TRANSLATE("About Paladin"));
 	fFileMenu->AddItem(new BMenuItem(aboutStr,
 		new BMessage(B_ABOUT_REQUESTED)));
+	fFileMenu->AddSeparatorItem();
+	BString quitString(B_TRANSLATE("Quit"));
+	fFileMenu->AddItem(new BMenuItem(quitString,
+		new BMessage(B_QUIT_REQUESTED), 'Q'));
 	fMenuBar->AddItem(fFileMenu);
 
 	// Source menu

--- a/Paladin/locales/en.catkeys
+++ b/Paladin/locales/en.catkeys
@@ -1,4 +1,4 @@
-1	English	application/x-vnd.dw-Paladin	585773182
+1	English	application/x-vnd.dw-Paladin	692112015
 Project	ProjectWindow		Project
 None	ProjectSettingsWindow		None
 Remove	CodeLibWindow		Remove
@@ -13,6 +13,7 @@ Delete current module	CodeLibWindow		Delete current module
 Search only system folders	FindOpenFileWindow		Search only system folders
 Emptying build cache	ProjectWindow		Emptying build cache
 Subversion	SCMManager		Subversion
+Quit	ProjectWindow		Quit
 Backspace	AsciiWindow	ASCII table description	Backspace
 This cannot be undone. Delete module?	CodeLibWindow		This cannot be undone. Delete module?
 New line	AsciiWindow	ASCII table description	New line


### PR DESCRIPTION
I've made just a few changes to get a clean base which compiles on Haiku R4.

Additional fixes:
- When a template was chosen, the original file permissions were also copied which resulted in read-only files
- Removed the obsolete B_FILE_NOT_FOUND message
- Added missing GNU Extension for asprint
- Added a Quit menu item in the File menu